### PR TITLE
feat: bootstrap domain and use case skeleton

### DIFF
--- a/src/application/usecases/HandleVoice.ts
+++ b/src/application/usecases/HandleVoice.ts
@@ -1,0 +1,47 @@
+import type { Buffer } from 'node:buffer';
+import type {
+  AsrPort,
+  LlmPort,
+  GitContentPort,
+  NotifierPort,
+  Clock,
+  IdempotencyStore,
+} from '../../domain/ports.js';
+
+export interface HandleVoiceInput {
+  chatId: string;
+  fileUniqueId: string;
+  audio: Buffer;
+  mimeType: string;
+}
+
+export class HandleVoice {
+  readonly asr: AsrPort;
+  readonly llm: LlmPort;
+  readonly git: GitContentPort;
+  readonly notifier: NotifierPort;
+  readonly clock: Clock;
+  readonly idem: IdempotencyStore;
+
+  constructor(
+    asr: AsrPort,
+    llm: LlmPort,
+    git: GitContentPort,
+    notifier: NotifierPort,
+    clock: Clock,
+    idem: IdempotencyStore,
+  ) {
+    this.asr = asr;
+    this.llm = llm;
+    this.git = git;
+    this.notifier = notifier;
+    this.clock = clock;
+    this.idem = idem;
+  }
+
+  // TODO: implement full voice handling flow
+  async execute(_input: HandleVoiceInput): Promise<void> {
+    // Placeholder implementation
+    return Promise.resolve();
+  }
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+// TODO: define required environment variables
+const envSchema = z.object({});
+
+export type Env = z.infer<typeof envSchema>;
+
+export function parseEnv(env: NodeJS.ProcessEnv): Env {
+  return envSchema.parse(env);
+}

--- a/src/domain/note.ts
+++ b/src/domain/note.ts
@@ -1,0 +1,48 @@
+import type { Topic } from './ports.js';
+
+const yamlEscape = (s: string) => s.replace(/"/g, '\\"');
+
+export function decideTopic(
+  result: { topic: Topic; confidence: number },
+  cfg: { threshold: number; fallback: Topic },
+): Topic {
+  return result.confidence >= cfg.threshold ? result.topic : cfg.fallback;
+}
+
+export function buildFrontmatter(params: {
+  title: string;
+  date: Date;
+  topic: Topic;
+  tags?: string[];
+  source: string;
+}): string {
+  const { title, date, topic, tags, source } = params;
+  const lines = [
+    '---',
+    `title: "${yamlEscape(title)}"`,
+    `date: ${date.toISOString()}`,
+    `topic: ${topic}`,
+  ];
+  if (tags && tags.length > 0) {
+    lines.push('tags:');
+    for (const tag of tags) {
+      lines.push(`  - "${yamlEscape(tag)}"`);
+    }
+  }
+  lines.push(`source: ${source}`, '---', '');
+  return lines.join('\n');
+}
+
+export function slugify(title: string): string {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\u0400-\u04FF\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function filePath(date: Date, topic: Topic, slug: string): string {
+  const iso = date.toISOString().split('T')[0];
+  return `${iso}/${topic}/${slug}.md`;
+}

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -1,0 +1,57 @@
+import type { Buffer } from 'node:buffer';
+
+export type Topic =
+  | 'dev-notes'
+  | 'product'
+  | 'edu'
+  | 'research'
+  | 'personal'
+  | 'inbox';
+
+export interface AsrPort {
+  transcribe(params: {
+    bytes: Buffer;
+    lang: 'ru-RU';
+    sampleRateHz: 48000;
+  }): Promise<{ text: string }>;
+}
+
+export interface LlmPort {
+  classify(params: { text: string; topics: Topic[] }): Promise<{
+    topic: Topic;
+    confidence: number;
+  }>;
+  generateTitle(params: { text: string }): Promise<{ title: string }>;
+}
+
+export interface GitContentPort {
+  putMarkdown(params: {
+    path: string;
+    content: string;
+    message: string;
+    author?: { name: string; email: string };
+    expectedSha?: string;
+  }): Promise<{ sha: string; commitSha: string; htmlUrl?: string }>;
+}
+
+export interface NotifierPort {
+  notify(chatId: string, message: string, options?: unknown): void | Promise<void>;
+}
+
+export interface Clock {
+  now(): Date;
+}
+
+export interface IdempotencyStore {
+  withKey<T>(key: string, fn: () => Promise<T>): Promise<{
+    status: 'fresh' | 'duplicate';
+    result: T;
+  }>;
+}
+
+export const ASR_PORT = Symbol('AsrPort');
+export const LLM_PORT = Symbol('LlmPort');
+export const GIT_CONTENT_PORT = Symbol('GitContentPort');
+export const NOTIFIER_PORT = Symbol('NotifierPort');
+export const CLOCK = Symbol('Clock');
+export const IDEMPOTENCY_STORE = Symbol('IdempotencyStore');

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,0 +1,49 @@
+export type AppErrorKind =
+  | 'Validation'
+  | 'Auth'
+  | 'RateLimit'
+  | 'Transient'
+  | 'External'
+  | 'Conflict'
+  | 'NotFound';
+
+export type AppService =
+  | 'telegram'
+  | 'speechkit'
+  | 'yandexgpt'
+  | 'github'
+  | 'app';
+
+export interface AppErrorOptions {
+  kind: AppErrorKind;
+  service: AppService;
+  code: string;
+  message: string;
+  retryable: boolean;
+  details?: unknown;
+  cause?: unknown;
+}
+
+export class AppError extends Error {
+  kind: AppErrorKind;
+  service: AppService;
+  code: string;
+  retryable: boolean;
+  details?: unknown;
+  cause?: unknown;
+
+  constructor(opts: AppErrorOptions) {
+    super(opts.message);
+    this.name = 'AppError';
+    this.kind = opts.kind;
+    this.service = opts.service;
+    this.code = opts.code;
+    this.retryable = opts.retryable;
+    this.details = opts.details;
+    this.cause = opts.cause;
+  }
+}
+
+export function isAppError(err: unknown): err is AppError {
+  return err instanceof AppError;
+}


### PR DESCRIPTION
## Summary
- define domain ports and topic taxonomy
- add note helpers and unified AppError
- scaffold HandleVoice use case and env config stub

## Testing
- `bun test`
- `bunx @biomejs/biome lint .`


------
https://chatgpt.com/codex/tasks/task_e_68c9978302788333b1aff98e465dd057